### PR TITLE
remove loggers with public or private keys

### DIFF
--- a/rexchain/api/views.py
+++ b/rexchain/api/views.py
@@ -66,8 +66,8 @@ class PayloadViewSet(viewsets.ModelViewSet):
             try:
                 # pub_key = _crypto.get_pub_key_from_pem(raw_public_key)
                 hex_raw_pub_key = _crypto.savify_key(pub_key)
-            except Exception as e:
-                logger.error("[Public Key Error]:{}, type:{}".format(e, type(e)))
+            except Exception:
+                logger.error("[Public Key Error] Non valid Public Key")
                 raise NonValidPubKey
 
             return Payload.objects.filter(public_key=hex_raw_pub_key).order_by('-id')
@@ -140,7 +140,7 @@ class AddressViewSet(viewsets.ModelViewSet):
             try:
                 pub_key_b64 = pubkey_base64_from_uri(raw_public_key)
 
-            except Exception as e:  # noqa: F841
+            except Exception:
                 raise NonValidPubKey
             else:
                 _address = Address.objects.get_or_create_rsa_address(pub_key_b64)

--- a/rexchain/blockchain/helpers.py
+++ b/rexchain/blockchain/helpers.py
@@ -194,9 +194,8 @@ class CryptoTools(object):
         '''This method create a pair RSA keys with entropy created by the user in FE'''
         try:
             privatekey = RSA.generate(2048, randfunc=self.entropy)
-        except Exception as e:  # noqa: F841
-            self.logger.error('{}'.format(e))
-            self.logger.error("[CryptoTool, create_key_with_entropy ERROR] Entropy not enough")
+        except Exception:
+            self.logger.error("[Create_key_with_entropy ERROR] Entropy not enough")
             privatekey = None
 
         if privatekey is None:

--- a/rexchain/blockchain/managers.py
+++ b/rexchain/blockchain/managers.py
@@ -169,7 +169,7 @@ class TransactionManager(models.Manager):
             _payload = json.dumps(data_sorted, separators=(',', ':'), ensure_ascii=False)
 
         except Exception as e:
-            logger.error("[create_tx1 ERROR]: {}, type:{}".format(e, type(e)))
+            logger.error("[create_tx ERROR]: {}, type:{}".format(e, type(e)))
 
         _is_valid_tx = False
         _rx_before = None
@@ -177,8 +177,8 @@ class TransactionManager(models.Manager):
         try:
             # Prescript unsavify method
             pub_key = self._crypto.un_savify_key(raw_pub_key)
-        except Exception as e:
-            logger.error("[Key is b64 WARNING]: {}, type:{}".format(e, type(e)))
+        except Exception:
+            logger.error("[create_tx WARNING]: The key is base64")
             # Attempt to create public key with base64 with js payload
             pub_key, raw_pub_key = pubkey_base64_to_rsa(raw_pub_key)
 
@@ -191,7 +191,7 @@ class TransactionManager(models.Manager):
         if _previous_hash == '0':
             # It's a initial transaction
             if self._crypto.verify(_payload, _signature, pub_key):
-                logger.info("[CREATE_TX] Tx valid!")
+                logger.info("[create_tx] Tx valid!")
                 _is_valid_tx = True
 
         else:


### PR DESCRIPTION
En este PR se actulizarón los loggers para que no muestren ninguna información sensible acerca de las llaves públicas y privadas utilizadas en RexChain.