### PR TITLE
Remove cached property

### DIFF
--- a/rexchain/blockchain/models.py
+++ b/rexchain/blockchain/models.py
@@ -114,7 +114,6 @@ class Transaction(models.Model):
         )
         self.raw_msg = msg.encode('utf-8')
 
-    @cached_property
     def get_previous_hash(self):
         ''' Get before hash transaction '''
         return self.previous_hash

--- a/rexchain/blockchain/models.py
+++ b/rexchain/blockchain/models.py
@@ -151,7 +151,6 @@ class Payload(Timestampable, IOBlockchainize, models.Model):
         ''' Fix 6 hours timedelta on rx '''
         return self.timestamp
 
-    @cached_property
     def get_before_hash(self):
         ''' Get before hash Payload '''
         return self.previous_hash


### PR DESCRIPTION
No existen funciones en segundo plano, es decir que method.delay()

Lo que se noto es que si existen métodos con la propiedad @cached_property, esto calcula un valor y lo guarda en cache.

Se quito dicha propiedad a los métodos que calculan el campo hash_before.

Esto hará que el calculo sea lento pero si obtenga el valor actualizado y no un valore previamente calculado. 