### PR TITLE
[RXTEAM-6242] Fix Rexchain timeouts

### DIFF
--- a/rexchain/blockchain/models.py
+++ b/rexchain/blockchain/models.py
@@ -93,7 +93,7 @@ class Transaction(models.Model):
         related_name='transactions', null=True, blank=True)
     signature = models.TextField(blank=True, default="")
     is_valid = models.BooleanField(default=False, blank=True)
-    txid = models.TextField(blank=True, default="")
+    txid = models.TextField(blank=True, default="", db_index=True)
     previous_hash = models.TextField(blank=True, default="")
     # Details
     details = JSONField(default=dict, blank=True)

--- a/rexchain/blockchain/views.py
+++ b/rexchain/blockchain/views.py
@@ -64,6 +64,12 @@ def tx_detail(request, hash_id=False):
             rx = Payload.objects.get(hash_id=hash_id)
         except:  # noqa : F841
             try:
+                # This line filters Payload objects based on the 'txid' of the
+                # related Transaction object. The double underscore ('__')
+                # signifies a lookup across the ForeignKey relationship
+                # ('transaction'). This translates to the SQL query with the
+                # INNER JOIN and the WHERE clause on blockchain_transaction.txid.
+                # For this reason, we use an index on Transaction.txid
                 rx = Payload.objects.get(transaction__txid=hash_id)
             except Exception as e:
                 logger.error("Error :{}, type({})".format(e, type(e)))


### PR DESCRIPTION
# Description

Attempt to reduce RexChain timeouts by indexing the `Transaction.txid` used in a fallback query.

## The code

```python
def tx_detail(request, hash_id=False):
    ''' Get a hash and return the blockchain model '''
    if request.GET.get("hash_id", False):
        hash_id = request.GET.get("hash_id")

    if hash_id:
        context = dict()
        try:
            rx = Payload.objects.get(hash_id=hash_id)
        except:  # noqa : F841
            try:
                rx = Payload.objects.get(transaction__txid=hash_id) # 🚨🚨🚨
            except Exception as e:
                logger.error("Error :{}, type({})".format(e, type(e)))
                return redirect("/block/?block_hash={}".format(hash_id))
```


## The query

```sql
SELECT
    "blockchain_payload"."id",
    "blockchain_payload"."created_at",
    "blockchain_payload"."updated_at",
    "blockchain_payload"."timestamp",
    "blockchain_payload"."readable",
    "blockchain_payload"."is_valid",
    "blockchain_payload"."signature",
    "blockchain_payload"."hash_id",
    "blockchain_payload"."previous_hash",
    "blockchain_payload"."raw_msg",
    "blockchain_payload"."data",
    "blockchain_payload"."public_key",
    "blockchain_payload"."transaction_id"
FROM
    "blockchain_payload"
INNER JOIN
    "blockchain_transaction"
ON
    ("blockchain_payload"."transaction_id" = "blockchain_transaction"."id")
WHERE
    "blockchain_transaction"."txid" = '...' -- The specific txid value varied in the logs
LIMIT 21
```

Heroku's Postgres diagnostics also warn us about this specific query:
![Screenshot 2025-04-16 at 7 41 57 p m](https://github.com/user-attachments/assets/643e961e-ee6f-4201-829c-756d129b5d2c)

## AI breakdown

1. The Problem Seen in the Logs:

- Heroku Logs (`heroku[router]`): You saw `H12 Request timeout` errors for requests like `GET /hash/eb4ee....` This means the web server (dyno) took longer than 30 seconds to process the request and send a response, so Heroku's router gave up and sent a timeout error (503 status) to the client.

- PostgreSQL Logs (`app[postgres.*]`): You saw lines like:
`LOG: duration: 42584.086 ms statement: SELECT ... FROM "blockchain_payload" INNER JOIN "blockchain_transaction" ON ... WHERE "blockchain_transaction"."txid" = '...' LIMIT 21`
This log entry shows the database itself took over 42 seconds just to execute the SELECT query needed to find the transaction details based on its `txid`.

2. The Connection:

- The Heroku timeout (`H12`) was a direct consequence of the extremely long database query time shown in the PostgreSQL logs. The web application had to wait for the database to finish its slow query before it could process the data and send a response. Since the query alone took much longer than 30 seconds, the entire request inevitably timed out.

3. What `db_index=True` Does:

- In Django (`models.py`): Adding `db_index=True` to the `txid = models.TextField(...)` line tells Django that you want the database to create an index on the `txid` column of the `blockchain_transaction` table.

- In the Database (PostgreSQL): When you run `python manage.py makemigrations` and `python manage.py migrate`, Django generates and executes the necessary SQL command (like `CREATE INDEX ... ON blockchain_transaction (txid);`). This command instructs PostgreSQL to build and maintain a special data structure (the index).

- How an Index Works: Think of a database index like the index at the back of a book. Instead of reading the whole book (scanning the entire table) to find mentions of a specific term (`txid23`), the database can look up the term in the index, which quickly points to the exact location(s) (table rows) where that term appears.

4. The Result:

By adding the database index to the txid column, the `SELECT ... WHERE "blockchain_transaction"."txid" = '...'` query becomes much, much faster. Instead of taking 30-40+ seconds scanning the table, it can use the index to find the required transaction almost instantly (typically in milliseconds).

This dramatic speedup in the database query means the overall request processing time for `/hash/<txid>` endpoints will drop significantly, falling well below the 30-second Heroku timeout limit. This should resolve the H12 errors you were
seeing for those specific requests.

# Changes:

- [x] feat: Index Transaction.txid to fix Heroku timeouts
- [x] docs: Add comment about the need for an index in fallback

# Jira Issue
https://prescrypto.atlassian.net/browse/RXTEAM-6242

-----